### PR TITLE
Aktivitet på barnetilsyn kan mangle

### DIFF
--- a/stonadsstatistikk-ef/src/main/kotlin/no/nav/familie/eksterne/kontrakter/ef/BehandlingDVH.kt
+++ b/stonadsstatistikk-ef/src/main/kotlin/no/nav/familie/eksterne/kontrakter/ef/BehandlingDVH.kt
@@ -39,7 +39,7 @@ data class VedtakBarnetilsynDVH(
         val vedtak: Vedtak? = null,
         val vedtaksperioder: List<VedtaksperiodeBarnetilsynDto>,
         val utbetalinger: List<Utbetaling>,
-        val aktivitetskrav: AktivitetsvilkårBarnetilsyn,
+        val aktivitetskrav: AktivitetsvilkårBarnetilsyn?,
         val funksjonellId: Long? = null,
         val stønadstype: StønadType,
         val perioderKontantstøtte: List<PeriodeMedBeløp>,


### PR DESCRIPTION
Hvis resultatet på vilkåret er "SKAL_IKKE_VURDERES"

Denne feiler i prod nå i iverksett
https://familie-prosessering.intern.nav.no/service/familie-ef-iverksett/gruppert?statusFilter=MANUELL_OPPF%C3%98LGING&callId=6b5fb7a5-74fa-44de-b133-494c931f4ab2

```kotlin
val svar =
                test.delvilkårsvurderinger.first().vurderinger.find { it.regelId == RegelId.ER_I_ARBEID_ELLER_FORBIGÅENDE_SYKDOM }?.svar
                ?: error("Finner ikke delvilkårvurderingen for arbeid aktivitet barnetilsyn")
```