### PR TITLE
Legg til sokersAktivitetsland i kompentanse

### DIFF
--- a/stonadsstatistikk/src/main/kotlin/no/nav/familie/eksterne/kontrakter/VedtakV2.kt
+++ b/stonadsstatistikk/src/main/kotlin/no/nav/familie/eksterne/kontrakter/VedtakV2.kt
@@ -16,7 +16,7 @@ data class VedtakDVHV2(
     val utbetalingsperioderV2: List<UtbetalingsperiodeDVHV2>,
     val kompetanseperioder: List<Kompetanse>? = null,
     val funksjonellId: String,
-    val behandlingÅrsakV2: BehandlingÅrsakV2,
+    val behandlingÅrsakV2: BehandlingÅrsakV2
 )
 
 data class UtbetalingsperiodeDVHV2(
@@ -47,6 +47,7 @@ data class Kompetanse(
     val fom: YearMonth,
     val tom: YearMonth?,
     val sokersaktivitet: SøkersAktivitet,
+    val sokersAktivitetsland: String? = null,
     val annenForeldersAktivitet: AnnenForeldersAktivitet? = null,
     val annenForeldersAktivitetsland: String? = null,
     val barnetsBostedsland: String? = null,


### PR DESCRIPTION
I https://github.com/navikt/familie-ba-sak/pull/2799 ble søkersAktivitetsland lagt til i kompetanse.

Legger til `sokersAktivitetsland` i kompetanse for VedtakDVHV2 slik at vi kan sende dataene til datavarehus. 