### PR TITLE
Opprydding Søkersaktivitet enums

### DIFF
--- a/stonadsstatistikk/README.md
+++ b/stonadsstatistikk/README.md
@@ -1,16 +1,17 @@
 ### Endringslogg
 
-| Dato       | Endring                                                                                                                            |
-|------------|------------------------------------------------------------------------------------------------------------------------------------|
-| 2022-09-21 | Lagt til fagsaktype for fagsaken for å skille mellom enslig mindreårig, institusjon og normale saker                               |
-| 2022-09-16 | Gjort søkers aktivitet nullable for å støtte migrering av eøs                                                                      |
-| 2022-06-14 | Lagt til flere enumverdier i SøkersAktivitet                                                                                       |
-| 2022-05-06 | Ny versjon av Vedtak(V2) med støtte for kompetanse og fjerning av felter som ikke var ibruk. Ny versjon vil kun bli brukt på aiven |
-| 2021-08-20 | Opprydding. behandlingÅrsak DØDSFALL endret til DØDSFALL_BRUKER. Fjernet KLAGE fra behandlingstype                                 |
-| 2021-06-29 | Lagt til behandlingÅrsak SATSENDRING                                                                                               |
-| 2021-04-29 | Lagt til behandlingÅrsak MIGRERING                                                                                                 |
-| 2021-02-01 | Utvidet med behandlingÅrsak                                                                                                        |
-| 2020-11-24 | Endret funksjonellId til optional                                                                                                  |
-| 2021-11-10 | Lagt til funksjonellId                                                                                                             |
-| 2021-10-21 | personIdent endret navn til person og gjort om til PersonDVH                                                                       |
-| 2021-09-09 | Første versjon                                                                                                                     |
+| Dato       | Endring                                                                                                                                                                                                                                                       |
+|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2022-09-23 | Ryddet i enums for SøkersAktivitet. Revertert ARBEIDER_I_NORGE og MOTTAR_UTBETALING_FRA_NAV_SOM_ERSTATTER_LØNN fordi det finnes meldinger med de enda på topic for å sikre bakoverkompabilitet hvis man skal lese gamle meldinger. Slettet ubrukte deprikerte |
+| 2022-09-21 | Lagt til fagsaktype for fagsaken for å skille mellom enslig mindreårig, institusjon og normale saker                                                                                                                                                          |
+| 2022-09-16 | Gjort søkers aktivitet nullable for å støtte migrering av eøs                                                                                                                                                                                                 |
+| 2022-06-14 | Lagt til flere enumverdier i SøkersAktivitet                                                                                                                                                                                                                  |
+| 2022-05-06 | Ny versjon av Vedtak(V2) med støtte for kompetanse og fjerning av felter som ikke var ibruk. Ny versjon vil kun bli brukt på aiven                                                                                                                            |
+| 2021-08-20 | Opprydding. behandlingÅrsak DØDSFALL endret til DØDSFALL_BRUKER. Fjernet KLAGE fra behandlingstype                                                                                                                                                            |
+| 2021-06-29 | Lagt til behandlingÅrsak SATSENDRING                                                                                                                                                                                                                          |
+| 2021-04-29 | Lagt til behandlingÅrsak MIGRERING                                                                                                                                                                                                                            |
+| 2021-02-01 | Utvidet med behandlingÅrsak                                                                                                                                                                                                                                   |
+| 2020-11-24 | Endret funksjonellId til optional                                                                                                                                                                                                                             |
+| 2021-11-10 | Lagt til funksjonellId                                                                                                                                                                                                                                        |
+| 2021-10-21 | personIdent endret navn til person og gjort om til PersonDVH                                                                                                                                                                                                  |
+| 2021-09-09 | Første versjon                                                                                                                                                                                                                                                |

--- a/stonadsstatistikk/src/main/kotlin/no/nav/familie/eksterne/kontrakter/VedtakV2.kt
+++ b/stonadsstatistikk/src/main/kotlin/no/nav/familie/eksterne/kontrakter/VedtakV2.kt
@@ -56,24 +56,20 @@ data class Kompetanse(
 )
 
 enum class SøkersAktivitet {
-    @Deprecated("Skal bruke ARBEIDER")
+    @Deprecated("Skal bruke ARBEIDER. Siste melding sendt 2022-09-05 med offset 27648")
     ARBEIDER_I_NORGE,
     ARBEIDER,
 
     SELVSTENDIG_NÆRINGSDRIVENDE,
 
-    @Deprecated("Skal bruke MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN")
+    @Deprecated("Skal bruke MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN, Sist sendt 2022-08-04 med offset 18122")
     MOTTAR_UTBETALING_FRA_NAV_SOM_ERSTATTER_LØNN,
     MOTTAR_UTBETALING_SOM_ERSTATTER_LØNN,
 
     UTSENDT_ARBEIDSTAKER_FRA_NORGE,
 
-    @Deprecated("Skal bruke MOTTAR_UFØRETRYGD")
-    MOTTAR_UFØRETRYGD_FRA_NORGE,
     MOTTAR_UFØRETRYGD,
 
-    @Deprecated("Skal bruke MOTTAR_PENSJON")
-    MOTTAR_PENSJON_FRA_NORGE,
     MOTTAR_PENSJON,
 
     ARBEIDER_PÅ_NORSKREGISTRERT_SKIP,


### PR DESCRIPTION
Sikret at kontrakten er bakoverkompatibel med den som eksisterer på topicen. I tilfeller man velger å lese gamle meldinger, som ved at man mister offset sin eller velger å sette offset manuelt.

Har brukt https://familie-ba-kafka-manager.intern.nav.no/index.html for å finne tidligste offset på topic(14653) og familie-ba-statistikk for å gjøre query for å finne meldinger med de deprikerte enumene(query i README i familie-ba-statistikk). 

De deprekerte enums bør ikke slettes før de er vekk fra topicen. Retention er 2 måneder, men kafka rydder med en garbage collector, så kan ta litt lengre tid en 2 måneder i praksis.
