### PR TITLE
Lagt til manglende behandlingsårsak for vedtak i KS

### DIFF
--- a/stonadsstatistikk-ks/src/main/kotlin/no/nav/familie/eksterne/kontrakter/Vedtak.kt
+++ b/stonadsstatistikk-ks/src/main/kotlin/no/nav/familie/eksterne/kontrakter/Vedtak.kt
@@ -79,6 +79,7 @@ enum class BehandlingÅrsak(val visningsnavn: String) {
     TEKNISK_ENDRING("Teknisk endring"),
     KORREKSJON_VEDTAKSBREV("Korrigere vedtak med egen brevmal"),
     SATSENDRING("Satsendring"),
+    BARNEHAGELISTE("Barnehageliste"),
 }
 
 enum class Kategori {


### PR DESCRIPTION
Vi får feil i `familie-ks-sak` når vi forsøker å kaste behandlingsårsaken `BARNEHAGELISTE` til enumen `BehandlingÅrsak`. Har nå lagt til den manglende enum verdien `BARNEHAGELISTE`.

Lenke til feilen: https://familie-prosessering.intern.nav.no/service/familie-ks-sak