### PR TITLE
Skal ikke lengre sende med utgifter for behandlingsstatistikk skolepenger

### DIFF
--- a/stonadsstatistikk-ef/src/main/kotlin/no/nav/familie/eksterne/kontrakter/ef/BehandlingDVH.kt
+++ b/stonadsstatistikk-ef/src/main/kotlin/no/nav/familie/eksterne/kontrakter/ef/BehandlingDVH.kt
@@ -83,7 +83,6 @@ data class VedtaksperiodeSkolepenger(
 
 data class UtgiftSkolepenger(
     val utgiftsdato: LocalDate,
-    val utgiftsbeløp: Int,
     val utbetaltBeløp: Int
 )
 


### PR DESCRIPTION
**Hvorfor?**
Ved overgang til nytt UI vil saksbehandler ikke lengre ta stilling til utgifter, bare stønadsbeløp.