### PR TITLE
Skal kunne sette behandlingsårsak til MANUELT_OPPRETTET

### DIFF
--- a/stonadsstatistikk-ef/src/main/kotlin/no/nav/familie/eksterne/kontrakter/ef/BehandlingDVH.kt
+++ b/stonadsstatistikk-ef/src/main/kotlin/no/nav/familie/eksterne/kontrakter/ef/BehandlingDVH.kt
@@ -115,7 +115,8 @@ enum class BehandlingÅrsak {
     G_OMREGNING,
     KORRIGERING_UTEN_BREV,
     PAPIRSØKNAD,
-    SATSENDRING
+    SATSENDRING,
+    MANUELT_OPPRETTET
 }
 
 enum class Vedtak {


### PR DESCRIPTION
Siden vi sender behandlingÅrsak til datavarehus og legger til ny i kontrakter må vi også legge til ny i eksterne kontrakter.

Henger sammen med https://github.com/navikt/familie-kontrakter/pull/814 

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-11878)

