### PR TITLE
Legg til SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID

### DIFF
--- a/stonadsstatistikk/src/main/kotlin/no/nav/familie/eksterne/kontrakter/VedtakV2.kt
+++ b/stonadsstatistikk/src/main/kotlin/no/nav/familie/eksterne/kontrakter/VedtakV2.kt
@@ -145,10 +145,11 @@ enum class BehandlingÅrsakV2(val visningsnavn: String) {
     OMREGNING_18ÅR("Omregning 18 år"),
     OMREGNING_SMÅBARNSTILLEGG("Omregning småbarnstillegg"),
     SMÅBARNSTILLEGG("Småbarnstillegg"),
+    SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID("Småbarnstillegg endring fram i tid"),
     MIGRERING("Migrering"),
     SATSENDRING("Satsendring"),
     ENDRE_MIGRERINGSDATO("Endre migreringsdato"),
-    HELMANUELL_MIGRERING("Manuell migrering")
+    HELMANUELL_MIGRERING("Manuell migrering"),
 }
 
 enum class KategoriV2 {


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18278)

Dersom vi har en endring i overgangsstønaden fram i tid skal småbarnstillegg vurderes automatisk og det skal ikke sendes ut vedtaksbrev. 

Lager egen behandlingsårsak for tilfellet. 