### PR TITLE
Legger til ny BehandlingÅrsak 'NY_UTVIDET_KLASSEKODE'

### DIFF
--- a/stonadsstatistikk/src/main/kotlin/no/nav/familie/eksterne/kontrakter/VedtakV2.kt
+++ b/stonadsstatistikk/src/main/kotlin/no/nav/familie/eksterne/kontrakter/VedtakV2.kt
@@ -151,6 +151,7 @@ enum class BehandlingÅrsakV2(val visningsnavn: String) {
     ENDRE_MIGRERINGSDATO("Endre migreringsdato"),
     HELMANUELL_MIGRERING("Manuell migrering"),
     MÅNEDLIG_VALUTAJUSTERING("Månedlig valutajustering"),
+    NY_UTVIDET_KLASSEKODE("Ny utvidet klassekode")
 }
 
 enum class KategoriV2 {


### PR DESCRIPTION
For å unngå feil mot Stønadstatistikk må vi utvide `BehandlingÅrsakV2` med den nye årsaken `NY_UTVIDET_KLASSEKODE` som er lagt til i `familie-ba-sak`.