### PR TITLE
Lagt til behandlingsårsak automatisk inntektsendring

### DIFF
--- a/stonadsstatistikk-ef/src/main/kotlin/no/nav/familie/eksterne/kontrakter/ef/BehandlingDVH.kt
+++ b/stonadsstatistikk-ef/src/main/kotlin/no/nav/familie/eksterne/kontrakter/ef/BehandlingDVH.kt
@@ -120,7 +120,8 @@ enum class BehandlingÅrsak {
     IVERKSETTE_KA_VEDTAK,
     PAPIRSØKNAD,
     SATSENDRING,
-    MANUELT_OPPRETTET
+    MANUELT_OPPRETTET,
+    AUTOMATISK_INNTEKTSENDRING
 }
 
 enum class Vedtak {


### PR DESCRIPTION
Fiks for å ikke få feilende test i iverksett. Sendes enda ikke noe statistikk på automatisk inntektsendring, men kommer nok i fremtiden.