### PR TITLE
NAV-24658: Utvider kontrakten til DVH med relatert behandling fagsystem

### DIFF
--- a/saksstatistikk/src/main/kotlin/no/nav/familie/eksterne/kontrakter/saksstatistikk/Saksstatistikk.kt
+++ b/saksstatistikk/src/main/kotlin/no/nav/familie/eksterne/kontrakter/saksstatistikk/Saksstatistikk.kt
@@ -12,6 +12,7 @@ data class BehandlingDVH(
     val funksjonellId: String,
     val behandlingId: String,
     val relatertBehandlingId: String? = null,
+    val relatertBehandlingFagsystem: String? = null,
     val sakId: String,
     val vedtakId: String? = null,
     val behandlingType: String,


### PR DESCRIPTION
Har behov for å utvide kontrakten til å også sende `relatertBehandlingFagsystem` for å enklere kunne skille mellom BA og KLAGE.