### PR TITLE
Bumpe ktlint, formaterer, supresser noen warnings

### DIFF
--- a/arbeidsoppfolging/src/main/kotlin/no/nav/familie/eksterne/kontrakter/arbeidsoppfolging/VedtakOvergangsstønadArbeidsoppfølging.kt
+++ b/arbeidsoppfolging/src/main/kotlin/no/nav/familie/eksterne/kontrakter/arbeidsoppfolging/VedtakOvergangsstønadArbeidsoppfølging.kt
@@ -8,12 +8,12 @@ data class VedtakOvergangsstønadArbeidsoppfølging(
     val barn: List<Barn>,
     val stønadstype: Stønadstype,
     val periode: List<Periode>,
-    val vedtaksresultat: Vedtaksresultat
+    val vedtaksresultat: Vedtaksresultat,
 )
 
 data class Barn(
     val fødselsnummer: String? = null,
-    val termindato: LocalDate? = null
+    val termindato: LocalDate? = null,
 )
 
 data class Periode(
@@ -26,13 +26,13 @@ data class Periode(
 enum class Stønadstype {
     OVERGANGSSTØNAD,
     BARNETILSYN,
-    SKOLEPENGER
+    SKOLEPENGER,
 }
 
 enum class Vedtaksresultat {
     INNVILGET,
     OPPHØRT,
-    AVSLÅTT
+    AVSLÅTT,
 }
 
 enum class Periodetype {
@@ -42,7 +42,7 @@ enum class Periodetype {
     SANKSJON,
     PERIODE_FØR_FØDSEL,
     UTVIDELSE,
-    NY_PERIODE_FOR_NYTT_BARN
+    NY_PERIODE_FOR_NYTT_BARN,
 }
 
 enum class Aktivitetstype {

--- a/bisys/src/main/kotlin/no/nav/familie/eksterne/kontrakter/bisys/BarnetilsynBisysResponse.kt
+++ b/bisys/src/main/kotlin/no/nav/familie/eksterne/kontrakter/bisys/BarnetilsynBisysResponse.kt
@@ -3,20 +3,20 @@ package no.nav.familie.eksterne.kontrakter.bisys
 import java.time.LocalDate
 
 data class BarnetilsynBisysResponse(
-    val barnetilsynBisysPerioder: List<BarnetilsynBisysPeriode>
+    val barnetilsynBisysPerioder: List<BarnetilsynBisysPeriode>,
 )
 
 data class BarnetilsynBisysPeriode(
     val periode: Periode,
-    val barnIdenter: List<String>
+    val barnIdenter: List<String>,
 )
 
 data class BarnetilsynBisysRequest(
     val ident: String,
-    val fomDato: LocalDate
+    val fomDato: LocalDate,
 )
 
 data class Periode(
     val fom: LocalDate,
-    val tom: LocalDate
+    val tom: LocalDate,
 )

--- a/bisys/src/main/kotlin/no/nav/familie/eksterne/kontrakter/bisys/BarnetrygdBisysMelding.kt
+++ b/bisys/src/main/kotlin/no/nav/familie/eksterne/kontrakter/bisys/BarnetrygdBisysMelding.kt
@@ -15,5 +15,5 @@ data class BarnEndretOpplysning(
 
 data class BarnetrygdBisysMelding(
     val søker: String,
-    val barn: List<BarnEndretOpplysning>
+    val barn: List<BarnEndretOpplysning>,
 )

--- a/pom.xml
+++ b/pom.xml
@@ -264,9 +264,9 @@
                 </executions>
                 <dependencies>
                     <dependency>
-                        <groupId>com.pinterest</groupId>
-                        <artifactId>ktlint</artifactId>
-                        <version>0.45.2</version>
+                        <groupId>com.pinterest.ktlint</groupId>
+                        <artifactId>ktlint-cli</artifactId>
+                        <version>1.5.0</version>
                     </dependency>
                     <!-- additional 3rd party ruleset(s) can be specified here -->
                 </dependencies>

--- a/saksstatistikk-ef/src/main/kotlin/no/nav/familie/eksterne/kontrakter/saksstatistikk/ef/BehandlingDVH.kt
+++ b/saksstatistikk-ef/src/main/kotlin/no/nav/familie/eksterne/kontrakter/saksstatistikk/ef/BehandlingDVH.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import java.time.LocalDate
 import java.time.ZonedDateTime
 
+@Suppress("ktlint:standard:max-line-length")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class BehandlingDVH(
     val behandlingId: Long, // Fagsystemets eksterne behandlings-ID
@@ -38,5 +39,5 @@ data class BehandlingDVH(
     val kravMottatt: LocalDate? = null, // Dato for når krav eller informasjon om at man må opprette revurdering ble mottatt
     val revurderingOpplysningskilde: String? = null, // Opplysningskilde til hvorfor det må gjøres en revurdering, eks MODIA
     val revurderingÅrsak: String? = null, // Årsak til revurdering, eks ENDRING_I_INNTEKT
-    val avslagAarsak: String? = null // Eks: VILKÅR_IKKE_OPPFYLT, BARN_OVER_ÅTTE_ÅR, STØNADSTID_OPPBRUKT, MANGLENDE_OPPLYSNINGER, MINDRE_INNTEKTSENDRINGER
+    val avslagAarsak: String? = null, // Eks: VILKÅR_IKKE_OPPFYLT, BARN_OVER_ÅTTE_ÅR, STØNADSTID_OPPBRUKT, MANGLENDE_OPPLYSNINGER, MINDRE_INNTEKTSENDRINGER
 )

--- a/saksstatistikk-ef/src/test/kotlin/no/nav/familie/eksterne/kontrakter/saksstatistikk/ef/BehandlingDVHTest.kt
+++ b/saksstatistikk-ef/src/test/kotlin/no/nav/familie/eksterne/kontrakter/saksstatistikk/ef/BehandlingDVHTest.kt
@@ -10,10 +10,8 @@ import java.time.LocalDate
 import java.time.ZonedDateTime
 
 internal class BehandlingDVHTest {
-
     @Test
     fun `serialiser og deserialiser, forvent ingen unntak`() {
-
         val mapper = ObjectMapper().registerModule(KotlinModule())
         mapper.registerModule(JavaTimeModule())
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
@@ -21,8 +19,8 @@ internal class BehandlingDVHTest {
         mapper.readValue<BehandlingDVH>(json)
     }
 
-    private fun opprettBehandlingstatistikk(): BehandlingDVH {
-        return BehandlingDVH(
+    private fun opprettBehandlingstatistikk(): BehandlingDVH =
+        BehandlingDVH(
             behandlingId = 123L,
             personIdent = "persinIdent",
             saksbehandler = "gjeldendeSaksbehandlerId",
@@ -43,7 +41,6 @@ internal class BehandlingDVHTest {
             sakId = 321L,
             kravMottatt = LocalDate.now(),
             revurderingÅrsak = "ENDRING_I_INNTEKT",
-            revurderingOpplysningskilde = "MODIA"
+            revurderingOpplysningskilde = "MODIA",
         )
-    }
 }

--- a/saksstatistikk-klage/src/main/kotlin/no/nav/familie/eksterne/kontrakter/saksstatistikk/klage/BehandlingsstatistikkKlage.kt
+++ b/saksstatistikk-klage/src/main/kotlin/no/nav/familie/eksterne/kontrakter/saksstatistikk/klage/BehandlingsstatistikkKlage.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import java.time.ZonedDateTime
 import java.util.UUID
 
+@Suppress("ktlint:standard:max-line-length")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class BehandlingsstatistikkKlage(
     val behandlingId: UUID, // Fagsystemets eksterne behandlings-ID

--- a/saksstatistikk-klage/src/test/kotlin/no/nav/familie/eksterne/kontrakter/saksstatistikk/klage/BehandlingsstatistikkKlageTest.kt
+++ b/saksstatistikk-klage/src/test/kotlin/no/nav/familie/eksterne/kontrakter/saksstatistikk/klage/BehandlingsstatistikkKlageTest.kt
@@ -10,10 +10,8 @@ import java.time.ZonedDateTime
 import java.util.UUID
 
 internal class BehandlingsstatistikkKlageTest {
-
     @Test
     fun `serialiser og deserialiser, forvent ingen unntak`() {
-
         val mapper = ObjectMapper().registerModule(KotlinModule())
         mapper.registerModule(JavaTimeModule())
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
@@ -21,8 +19,8 @@ internal class BehandlingsstatistikkKlageTest {
         mapper.readValue<BehandlingsstatistikkKlage>(json)
     }
 
-    private fun opprettBehandlingstatistikk(): BehandlingsstatistikkKlage {
-        return BehandlingsstatistikkKlage(
+    private fun opprettBehandlingstatistikk(): BehandlingsstatistikkKlage =
+        BehandlingsstatistikkKlage(
             behandlingId = UUID.randomUUID(),
             behandlingType = "Klage",
             fagsystem = "EF",
@@ -40,7 +38,6 @@ internal class BehandlingsstatistikkKlageTest {
             mottattTid = ZonedDateTime.now(),
             behandlingMetode = "MANUELL",
             avsender = "NAV Enslig forelder",
-            relatertEksternBehandlingId = "1"
+            relatertEksternBehandlingId = "1",
         )
-    }
 }

--- a/saksstatistikk/src/main/kotlin/no/nav/familie/eksterne/kontrakter/saksstatistikk/Saksstatistikk.kt
+++ b/saksstatistikk/src/main/kotlin/no/nav/familie/eksterne/kontrakter/saksstatistikk/Saksstatistikk.kt
@@ -48,7 +48,7 @@ data class ResultatBegrunnelseDVH(
     val fom: LocalDate? = null,
     val tom: LocalDate? = null,
     val type: String,
-    val vedtakBegrunnelse: String
+    val vedtakBegrunnelse: String,
 )
 
 data class SakDVH(
@@ -63,13 +63,13 @@ data class SakDVH(
     val sakStatus: String,
     val avsender: String,
     val versjon: String,
-    val ytelseType: String = "BARNETRYGD"
+    val ytelseType: String = "BARNETRYGD",
 )
 
 data class AktørDVH(
     val aktorId: Long,
     val rolle: String,
-    val rolleBeskrivelse: String? = null
+    val rolleBeskrivelse: String? = null,
 )
 
 data class SettPåVent(

--- a/saksstatistikk/src/test/kotlin/no/nav/familie/eksterne/kontrakter/saksstatistikk/SaksstatistikkTest.kt
+++ b/saksstatistikk/src/test/kotlin/no/nav/familie/eksterne/kontrakter/saksstatistikk/SaksstatistikkTest.kt
@@ -14,145 +14,155 @@ import com.worldturner.medeia.api.jackson.MedeiaJacksonApi
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.ZonedDateTime
-import java.util.*
+import java.util.UUID
 
 class SaksstatistikkTest {
-
     private val api = MedeiaJacksonApi()
     private val jsonFactory = JsonFactory()
-    private val behandlingSchemaValidator = api.loadSchema(
-        UrlSchemaSource(
-            javaClass.getResource("/schema/behandling-schema.json")
+    private val behandlingSchemaValidator =
+        api.loadSchema(
+            UrlSchemaSource(
+                javaClass.getResource("/schema/behandling-schema.json"),
+            ),
         )
-    )
-    private val sakSchemaValidator = api.loadSchema(
-        UrlSchemaSource(
-            javaClass.getResource("/schema/sak-schema.json")
+    private val sakSchemaValidator =
+        api.loadSchema(
+            UrlSchemaSource(
+                javaClass.getResource("/schema/sak-schema.json"),
+            ),
         )
-    )
-    private val objectMapper = ObjectMapper()
-        .setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
-        .setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE)
-        .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
-        .setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.ANY)
-        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-        .registerKotlinModule()
-        .registerModule(JavaTimeModule())
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    private val objectMapper =
+        ObjectMapper()
+            .setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+            .setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE)
+            .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+            .setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.ANY)
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .registerKotlinModule()
+            .registerModule(JavaTimeModule())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
     @Test
     fun `kun required satt, skal validere mot behandling schema`() {
-        val behandlingDVH = BehandlingDVH(
-            funksjonellTid = ZonedDateTime.now(),
-            tekniskTid = ZonedDateTime.now(),
-            mottattDato = ZonedDateTime.now(),
-            registrertDato = ZonedDateTime.now(),
-            behandlingId = "behandlingId",
-            sakId = "sakId",
-            behandlingType = "behandlingType",
-            behandlingStatus = "behandlingStatus",
-            behandlingKategori = "ORDINÆR",
-            behandlingAarsak = "SØKNAD",
-            automatiskBehandlet = false,
-            utenlandstilsnitt = "EØS",
-            ansvarligEnhetKode = "kode",
-            behandlendeEnhetKode = "kode",
-            ansvarligEnhetType = "ansvarligEnhetType",
-            behandlendeEnhetType = "behandlendeEnhetType",
-            totrinnsbehandling = true,
-            avsender = "avsender",
-            versjon = "2",
-            funksjonellId = UUID.randomUUID().toString()
-        )
+        val behandlingDVH =
+            BehandlingDVH(
+                funksjonellTid = ZonedDateTime.now(),
+                tekniskTid = ZonedDateTime.now(),
+                mottattDato = ZonedDateTime.now(),
+                registrertDato = ZonedDateTime.now(),
+                behandlingId = "behandlingId",
+                sakId = "sakId",
+                behandlingType = "behandlingType",
+                behandlingStatus = "behandlingStatus",
+                behandlingKategori = "ORDINÆR",
+                behandlingAarsak = "SØKNAD",
+                automatiskBehandlet = false,
+                utenlandstilsnitt = "EØS",
+                ansvarligEnhetKode = "kode",
+                behandlendeEnhetKode = "kode",
+                ansvarligEnhetType = "ansvarligEnhetType",
+                behandlendeEnhetType = "behandlendeEnhetType",
+                totrinnsbehandling = true,
+                avsender = "avsender",
+                versjon = "2",
+                funksjonellId = UUID.randomUUID().toString(),
+            )
 
-        val validatedParser = api.decorateJsonParser(
-            behandlingSchemaValidator,
-            jsonFactory.createParser(objectMapper.writeValueAsBytes(behandlingDVH))
-        )
+        val validatedParser =
+            api.decorateJsonParser(
+                behandlingSchemaValidator,
+                jsonFactory.createParser(objectMapper.writeValueAsBytes(behandlingDVH)),
+            )
         api.parseAll(validatedParser)
     }
 
     @Test
     fun `alle parametere satt, skal validere mot behandling schema`() {
-        val behandlingDVH = BehandlingDVH(
-            funksjonellTid = ZonedDateTime.now(),
-            tekniskTid = ZonedDateTime.now(),
-            mottattDato = ZonedDateTime.now(),
-            registrertDato = ZonedDateTime.now(),
-            behandlingId = "behandlingId",
-            funksjonellId = UUID.randomUUID().toString(),
-            sakId = "sakId",
-            behandlingType = "behandlingType",
-            behandlingStatus = "behandlingStatus",
-            behandlingKategori = "ORDINÆR",
-            behandlingUnderkategori = "småbarnstillegg",
-            behandlingAarsak = "SØKNAD",
-            automatiskBehandlet = false,
-            utenlandstilsnitt = "EØS",
-            ansvarligEnhetKode = "kode",
-            behandlendeEnhetKode = "kode",
-            ansvarligEnhetType = "ansvarligEnhetType",
-            behandlendeEnhetType = "behandlendeEnhetType",
-            totrinnsbehandling = true,
-            avsender = "avsender",
-            versjon = "2",
-            vedtaksDato = LocalDate.now(),
-            relatertBehandlingId = "relatertBehandlingId",
-            vedtakId = "vedtakId",
-            resultat = "resultat",
-            resultatBegrunnelser = listOf(
-                ResultatBegrunnelseDVH(
-                    fom = LocalDate.now(),
-                    tom = LocalDate.now().plusMonths(1),
-                    type = "INNVILGET",
-                    vedtakBegrunnelse = "INNVILGET_BOSATT_I_NORGE"
-                )
-            ),
-            behandlingTypeBeskrivelse = "behandlingTypeBeskrivelse",
-            behandlingStatusBeskrivelse = "behandlingStatusBeskrivelse",
-            utenlandstilsnittBeskrivelse = "utenlandstilsnittBeskrivelse",
-            beslutter = "beslutter",
-            saksbehandler = "saksbehandler",
-            behandlingOpprettetAv = "behandlingOpprettetAv",
-            behandlingOpprettetType = "behandlingOpprettetType",
-            behandlingOpprettetTypeBeskrivelse = "behandlingOpprettetTypeBeskrivelse",
-            førsteInnvilgedeVilkårsdato = LocalDate.now(),
-            settPaaVent = SettPåVent(
-                frist = ZonedDateTime.now(),
-                tidSattPaaVent = ZonedDateTime.now(),
-                aarsak = "AVVENTER_DOKUMENTASJON",
+        val behandlingDVH =
+            BehandlingDVH(
+                funksjonellTid = ZonedDateTime.now(),
+                tekniskTid = ZonedDateTime.now(),
+                mottattDato = ZonedDateTime.now(),
+                registrertDato = ZonedDateTime.now(),
+                behandlingId = "behandlingId",
+                funksjonellId = UUID.randomUUID().toString(),
+                sakId = "sakId",
+                behandlingType = "behandlingType",
+                behandlingStatus = "behandlingStatus",
+                behandlingKategori = "ORDINÆR",
+                behandlingUnderkategori = "småbarnstillegg",
+                behandlingAarsak = "SØKNAD",
+                automatiskBehandlet = false,
+                utenlandstilsnitt = "EØS",
+                ansvarligEnhetKode = "kode",
+                behandlendeEnhetKode = "kode",
+                ansvarligEnhetType = "ansvarligEnhetType",
+                behandlendeEnhetType = "behandlendeEnhetType",
+                totrinnsbehandling = true,
+                avsender = "avsender",
+                versjon = "2",
+                vedtaksDato = LocalDate.now(),
+                relatertBehandlingId = "relatertBehandlingId",
+                vedtakId = "vedtakId",
+                resultat = "resultat",
+                resultatBegrunnelser =
+                    listOf(
+                        ResultatBegrunnelseDVH(
+                            fom = LocalDate.now(),
+                            tom = LocalDate.now().plusMonths(1),
+                            type = "INNVILGET",
+                            vedtakBegrunnelse = "INNVILGET_BOSATT_I_NORGE",
+                        ),
+                    ),
+                behandlingTypeBeskrivelse = "behandlingTypeBeskrivelse",
+                behandlingStatusBeskrivelse = "behandlingStatusBeskrivelse",
+                utenlandstilsnittBeskrivelse = "utenlandstilsnittBeskrivelse",
+                beslutter = "beslutter",
+                saksbehandler = "saksbehandler",
+                behandlingOpprettetAv = "behandlingOpprettetAv",
+                behandlingOpprettetType = "behandlingOpprettetType",
+                behandlingOpprettetTypeBeskrivelse = "behandlingOpprettetTypeBeskrivelse",
+                førsteInnvilgedeVilkårsdato = LocalDate.now(),
+                settPaaVent =
+                    SettPåVent(
+                        frist = ZonedDateTime.now(),
+                        tidSattPaaVent = ZonedDateTime.now(),
+                        aarsak = "AVVENTER_DOKUMENTASJON",
+                    ),
             )
-        )
 
-        val validatedParser = api.decorateJsonParser(
-            behandlingSchemaValidator,
-            jsonFactory.createParser(objectMapper.writeValueAsBytes(behandlingDVH))
-        )
+        val validatedParser =
+            api.decorateJsonParser(
+                behandlingSchemaValidator,
+                jsonFactory.createParser(objectMapper.writeValueAsBytes(behandlingDVH)),
+            )
         api.parseAll(validatedParser)
     }
 
     @Test
     fun `skal validere mot sak schema`() {
-        val sakDVH = SakDVH(
-            funksjonellTid = ZonedDateTime.now(),
-            tekniskTid = ZonedDateTime.now(),
-            opprettetDato = LocalDate.now(),
-            funksjonellId = UUID.randomUUID().toString(),
-            sakId = "sakId",
-            aktorId = 123,
-            bostedsland = "NO",
-            aktorer = listOf(AktørDVH(1, "rolle", "beskrivelse")),
-            sakStatus = "sakStatus",
-            avsender = "avsender",
-            versjon = "2"
-        )
+        val sakDVH =
+            SakDVH(
+                funksjonellTid = ZonedDateTime.now(),
+                tekniskTid = ZonedDateTime.now(),
+                opprettetDato = LocalDate.now(),
+                funksjonellId = UUID.randomUUID().toString(),
+                sakId = "sakId",
+                aktorId = 123,
+                bostedsland = "NO",
+                aktorer = listOf(AktørDVH(1, "rolle", "beskrivelse")),
+                sakStatus = "sakStatus",
+                avsender = "avsender",
+                versjon = "2",
+            )
 
-        val validatedParser = api.decorateJsonParser(
-            sakSchemaValidator,
-            jsonFactory.createParser(objectMapper.writeValueAsBytes(sakDVH))
-        )
+        val validatedParser =
+            api.decorateJsonParser(
+                sakSchemaValidator,
+                jsonFactory.createParser(objectMapper.writeValueAsBytes(sakDVH)),
+            )
         api.parseAll(validatedParser)
     }
 }

--- a/skatteetaten/src/main/kotlin/no/nav/familie/eksterne/kontrakter/skatteetaten/SkatteetatenPeriode.kt
+++ b/skatteetaten/src/main/kotlin/no/nav/familie/eksterne/kontrakter/skatteetaten/SkatteetatenPeriode.kt
@@ -10,24 +10,25 @@ import javax.validation.constraints.NotNull
  * @param tomMaaned Den siste måneden i perioden
  */
 data class SkatteetatenPeriode(
-
     @get:NotNull @field:JsonProperty("fraMaaned") val fraMaaned: String,
-
     @get:NotNull @field:JsonProperty("delingsprosent") val delingsprosent: Delingsprosent,
-
-    @field:JsonProperty("tomMaaned") val tomMaaned: String? = null
+    @field:JsonProperty("tomMaaned") val tomMaaned: String? = null,
 ) {
-
     /**
      * For perioder som løper i nytt fagsystem, vil \"delingsprosent\" alltid være \"0\" eller \"50\". \"usikker\" tilsvarer kode \"3\" i gammelt fagsystem
      * Values: _0,_50,usikker
      */
-    enum class Delingsprosent(val value: String) {
+    @Suppress("ktlint:standard:enum-entry-name-case") // Ønsker ikke endre på kontrakten for å gjøre uppercase
+    enum class Delingsprosent(
+        val value: String,
+    ) {
+        @JsonProperty("0")
+        _0("0"),
 
-        @JsonProperty("0") _0("0"),
+        @JsonProperty("50")
+        _50("50"),
 
-        @JsonProperty("50") _50("50"),
-
-        @JsonProperty("usikker") usikker("usikker");
+        @JsonProperty("usikker")
+        usikker("usikker"),
     }
 }

--- a/skatteetaten/src/main/kotlin/no/nav/familie/eksterne/kontrakter/skatteetaten/SkatteetatenPerioder.kt
+++ b/skatteetaten/src/main/kotlin/no/nav/familie/eksterne/kontrakter/skatteetaten/SkatteetatenPerioder.kt
@@ -12,14 +12,11 @@ import javax.validation.constraints.NotNull
  * @param perioder
  */
 data class SkatteetatenPerioder(
-
     @get:NotNull
     @field:JsonProperty("ident") val ident: String,
-
     @get:NotNull
     @field:JsonProperty("sisteVedtakPaaIdent") val sisteVedtakPaaIdent: LocalDateTime,
-
     @get:NotNull
     @field:Valid
-    @field:JsonProperty("perioder") val perioder: List<SkatteetatenPeriode>
+    @field:JsonProperty("perioder") val perioder: List<SkatteetatenPeriode>,
 )

--- a/skatteetaten/src/main/kotlin/no/nav/familie/eksterne/kontrakter/skatteetaten/SkatteetatenPerioderRequest.kt
+++ b/skatteetaten/src/main/kotlin/no/nav/familie/eksterne/kontrakter/skatteetaten/SkatteetatenPerioderRequest.kt
@@ -8,10 +8,8 @@ import javax.validation.constraints.NotNull
  * @param identer Liste over fødselsnumre det ønskes opplysninger om.
  */
 data class SkatteetatenPerioderRequest(
-
     @get:NotNull
     @field:JsonProperty("aar") val aar: String,
-
     @get:NotNull
-    @field:JsonProperty("identer") val identer: List<String>
+    @field:JsonProperty("identer") val identer: List<String>,
 )

--- a/skatteetaten/src/main/kotlin/no/nav/familie/eksterne/kontrakter/skatteetaten/SkatteetatenPerioderResponse.kt
+++ b/skatteetaten/src/main/kotlin/no/nav/familie/eksterne/kontrakter/skatteetaten/SkatteetatenPerioderResponse.kt
@@ -8,7 +8,6 @@ import javax.validation.Valid
  * @param brukere
  */
 data class SkatteetatenPerioderResponse(
-
     @field:Valid
-    @field:JsonProperty("brukere") val brukere: List<SkatteetatenPerioder> = emptyList()
+    @field:JsonProperty("brukere") val brukere: List<SkatteetatenPerioder> = emptyList(),
 )

--- a/skatteetaten/src/main/kotlin/no/nav/familie/eksterne/kontrakter/skatteetaten/SkatteetatenPerson.kt
+++ b/skatteetaten/src/main/kotlin/no/nav/familie/eksterne/kontrakter/skatteetaten/SkatteetatenPerson.kt
@@ -10,10 +10,8 @@ import javax.validation.constraints.NotNull
  * @param sisteVedtakPaaIdent Tidspunkt for siste vedtak (systemtidspunkt)
  */
 data class SkatteetatenPerson(
-
     @get:NotNull
     @field:JsonProperty("ident") val ident: String,
-
     @get:NotNull
-    @field:JsonProperty("sisteVedtakPaaIdent") val sisteVedtakPaaIdent: LocalDateTime
+    @field:JsonProperty("sisteVedtakPaaIdent") val sisteVedtakPaaIdent: LocalDateTime,
 )

--- a/skatteetaten/src/main/kotlin/no/nav/familie/eksterne/kontrakter/skatteetaten/SkatteetatenPersonerResponse.kt
+++ b/skatteetaten/src/main/kotlin/no/nav/familie/eksterne/kontrakter/skatteetaten/SkatteetatenPersonerResponse.kt
@@ -8,7 +8,6 @@ import javax.validation.Valid
  * @param brukere
  */
 data class SkatteetatenPersonerResponse(
-
     @field:Valid
-    @field:JsonProperty("brukere") val brukere: List<SkatteetatenPerson> = emptyList()
+    @field:JsonProperty("brukere") val brukere: List<SkatteetatenPerson> = emptyList(),
 )

--- a/stonadsstatistikk-ef/src/main/kotlin/no/nav/familie/eksterne/kontrakter/ef/BehandlingDVH.kt
+++ b/stonadsstatistikk-ef/src/main/kotlin/no/nav/familie/eksterne/kontrakter/ef/BehandlingDVH.kt
@@ -6,6 +6,7 @@ import java.time.ZonedDateTime
 @Deprecated("Bruk BehandlingOvergangsstønadDVH")
 typealias BehandlingDVH = VedtakOvergangsstønadDVH
 
+@Suppress("ktlint:standard:max-line-length")
 data class VedtakOvergangsstønadDVH(
     val fagsakId: Long, // Ekstern fagsakId
     val behandlingId: Long, // Ekstern behandlingId
@@ -26,7 +27,7 @@ data class VedtakOvergangsstønadDVH(
     val kravMottatt: LocalDate? = null,
     val årsakRevurdering: ÅrsakRevurdering? = null,
     val avslagÅrsak: String? = null, // F.eks: VILKÅR_IKKE_OPPFYLT, BARN_OVER_ÅTTE_ÅR, STØNADSTID_OPPBRUKT, MANGLENDE_OPPLYSNINGER, MINDRE_INNTEKTSENDRINGER
-    val eøsUnntak: EøsUnntak? = null
+    val eøsUnntak: EøsUnntak? = null,
 )
 
 data class VedtakBarnetilsynDVH(
@@ -51,7 +52,7 @@ data class VedtakBarnetilsynDVH(
     val kravMottatt: LocalDate? = null,
     val årsakRevurdering: ÅrsakRevurdering? = null,
     val avslagÅrsak: String? = null,
-    val eøsUnntak: EøsUnntak? = null
+    val eøsUnntak: EøsUnntak? = null,
 )
 
 data class VedtakSkolepenger(
@@ -74,26 +75,26 @@ data class VedtakSkolepenger(
     val kravMottatt: LocalDate? = null,
     val årsakRevurdering: ÅrsakRevurdering? = null,
     val avslagÅrsak: String? = null,
-    val eøsUnntak: EøsUnntak? = null
+    val eøsUnntak: EøsUnntak? = null,
 )
 
 data class VedtaksperiodeSkolepenger(
     val skoleår: Int, // 2021 = Skoleåret 2021/2022
     val perioder: List<Delårsperiode>, // Det er mulig med flere studieperioder innenfor samme skoleår
     val utgifter: List<UtgiftSkolepenger>,
-    val maksSatsForSkoleår: Int
+    val maksSatsForSkoleår: Int,
 )
 
 data class UtgiftSkolepenger(
     val utgiftsdato: LocalDate,
-    val utbetaltBeløp: Int
+    val utbetaltBeløp: Int,
 )
 
 data class Delårsperiode(
     val studietype: Studietype,
     val datoFra: LocalDate,
     val datoTil: LocalDate,
-    val studiebelastning: Int
+    val studiebelastning: Int,
 )
 
 enum class Studietype {
@@ -106,7 +107,7 @@ enum class BehandlingType {
     REVURDERING, // Inkluderer opphør
     KLAGE,
     MIGRERING_FRA_INFOTRYGD,
-    TILBAKEFØRING_TIL_INFOTRYGD
+    TILBAKEFØRING_TIL_INFOTRYGD,
 }
 
 enum class BehandlingÅrsak {
@@ -121,25 +122,30 @@ enum class BehandlingÅrsak {
     PAPIRSØKNAD,
     SATSENDRING,
     MANUELT_OPPRETTET,
-    AUTOMATISK_INNTEKTSENDRING
+    AUTOMATISK_INNTEKTSENDRING,
 }
 
 enum class Vedtak {
     INNVILGET,
     OPPHØRT,
-    AVSLÅTT
+    AVSLÅTT,
 }
 
 enum class Adressebeskyttelse {
     STRENGT_FORTROLIG,
     STRENGT_FORTROLIG_UTLAND,
     FORTROLIG,
-    UGRADERT
+    UGRADERT,
 }
 
-data class Person(val personIdent: String? = null)
+data class Person(
+    val personIdent: String? = null,
+)
 
-data class Barn(val personIdent: String? = null, val termindato: LocalDate? = null)
+data class Barn(
+    val personIdent: String? = null,
+    val termindato: LocalDate? = null,
+)
 
 data class Utbetaling(
     val beløp: Int,
@@ -148,18 +154,18 @@ data class Utbetaling(
     val inntektsreduksjon: Int,
     val fraOgMed: LocalDate,
     val tilOgMed: LocalDate,
-    val utbetalingsdetalj: Utbetalingsdetalj
+    val utbetalingsdetalj: Utbetalingsdetalj,
 )
 
 data class Utbetalingsdetalj(
     val gjelderPerson: Person,
     val klassekode: String, // Identifiserer detaljert stønadstype i oppdragsystemet: "EFOG", "EFBT" og "EFSP"
-    val delytelseId: String
+    val delytelseId: String,
 ) // Identifiderer utbetalingen i oppdragssystemet
 
 data class VilkårsvurderingDto(
     val vilkår: Vilkår,
-    val resultat: Vilkårsresultat
+    val resultat: Vilkårsresultat,
 )
 
 enum class Vilkårsresultat {
@@ -168,7 +174,7 @@ enum class Vilkårsresultat {
     IKKE_OPPFYLT,
     IKKE_AKTUELL,
     IKKE_TATT_STILLING_TIL,
-    SKAL_IKKE_VURDERES;
+    SKAL_IKKE_VURDERES,
 }
 
 enum class Vilkår {
@@ -188,17 +194,20 @@ enum class Vilkår {
     DOKUMENTASJON_TILSYNSUTGIFTER,
     RETT_TIL_OVERGANGSSTØNAD,
     DOKUMENTASJON_AV_UTDANNING,
-    ER_UTDANNING_HENSIKTSMESSIG;
+    ER_UTDANNING_HENSIKTSMESSIG,
 }
 
 enum class AktivitetsvilkårBarnetilsyn {
     ER_I_ARBEID,
     ETABLERER_EGEN_VIRKSOMHET,
     HAR_FORBIGÅENDE_SYKDOM,
-    NEI
+    NEI,
 }
 
-data class Aktivitetskrav(val aktivitetspliktInntrefferDato: LocalDate?, val harSagtOppArbeidsforhold: Boolean?)
+data class Aktivitetskrav(
+    val aktivitetspliktInntrefferDato: LocalDate?,
+    val harSagtOppArbeidsforhold: Boolean?,
+)
 
 @Deprecated("Bruk VedtaksperiodeOvergangsstønadDto")
 typealias VedtaksperiodeDto = VedtaksperiodeOvergangsstønadDto
@@ -207,20 +216,20 @@ data class VedtaksperiodeOvergangsstønadDto(
     val fraOgMed: LocalDate,
     val tilOgMed: LocalDate,
     val aktivitet: AktivitetType,
-    val periodeType: VedtaksperiodeType
+    val periodeType: VedtaksperiodeType,
 )
 
 data class VedtaksperiodeBarnetilsynDto(
     val fraOgMed: LocalDate,
     val tilOgMed: LocalDate,
     val utgifter: Int,
-    val antallBarn: Int
+    val antallBarn: Int,
 )
 
 data class PeriodeMedBeløp(
     val fraOgMed: LocalDate,
     val tilOgMed: LocalDate,
-    val beløp: Int
+    val beløp: Int,
 )
 
 enum class VedtaksperiodeType {
@@ -230,7 +239,7 @@ enum class VedtaksperiodeType {
     SANKSJON,
     PERIODE_FØR_FØDSEL,
     UTVIDELSE,
-    NY_PERIODE_FOR_NYTT_BARN
+    NY_PERIODE_FOR_NYTT_BARN,
 }
 
 enum class AktivitetType {
@@ -259,16 +268,16 @@ enum class AktivitetType {
 enum class StønadType {
     OVERGANGSSTØNAD,
     BARNETILSYN,
-    SKOLEPENGER
+    SKOLEPENGER,
 }
 
 data class ÅrsakRevurdering(
     val opplysningskilde: String,
-    val årsak: String
+    val årsak: String,
 )
 
 data class EøsUnntak(
     val medlemMerEnn5ÅrEøs: Boolean,
     val medlemMerEnn5ÅrEøsAnnenForelderTrygdedekketINorge: Boolean,
-    val oppholderSegIAnnetEøsLand: Boolean
+    val oppholderSegIAnnetEøsLand: Boolean,
 )

--- a/stonadsstatistikk-ef/src/test/kotlin/no/nav/familie/eksterne/kontrakter/ef/BehandlingDVHTest.kt
+++ b/stonadsstatistikk-ef/src/test/kotlin/no/nav/familie/eksterne/kontrakter/ef/BehandlingDVHTest.kt
@@ -10,52 +10,56 @@ import java.time.LocalDate
 import java.time.ZonedDateTime
 
 class BehandlingDVHTest {
-
-    private val vedtak = BehandlingDVH(
-        fagsakId = 100L,
-        behandlingId = 123L,
-        relatertBehandlingId = 110L,
-        adressebeskyttelse = Adressebeskyttelse.UGRADERT,
-        tidspunktVedtak = ZonedDateTime.now(),
-        vilkårsvurderinger = listOf(
-            VilkårsvurderingDto(Vilkår.LOVLIG_OPPHOLD, Vilkårsresultat.OPPFYLT),
-            VilkårsvurderingDto(Vilkår.SIVILSTAND, Vilkårsresultat.OPPFYLT)
-        ),
-        person = Person(personIdent = "5634422"),
-        barn = listOf(Barn(personIdent = "6442433")),
-        behandlingType = BehandlingType.REVURDERING,
-        behandlingÅrsak = BehandlingÅrsak.SØKNAD,
-        vedtak = Vedtak.INNVILGET,
-        vedtaksperioder = listOf(
-            VedtaksperiodeDto(
-                LocalDate.of(2021, 3, 1),
-                LocalDate.of(2024, 2, 29),
-                AktivitetType.BARNET_ER_SYKT, VedtaksperiodeType.HOVEDPERIODE
-            )
-        ),
-        utbetalinger = listOf(
-            Utbetaling(
-                beløp = 100,
-                samordningsfradrag = 0,
-                inntekt = 100,
-                inntektsreduksjon = 0,
-                LocalDate.of(2021, 3, 1),
-                LocalDate.of(2024, 2, 29),
-                Utbetalingsdetalj(Person(personIdent = "5634422"), "EFOG", "EF-123-EF-019")
-            )
-        ),
-        aktivitetskrav = Aktivitetskrav(
-            aktivitetspliktInntrefferDato = LocalDate.of(2021, 3, 1),
-            harSagtOppArbeidsforhold = false
-        ),
-        stønadstype = StønadType.OVERGANGSSTØNAD,
-        kravMottatt = LocalDate.now(),
-        årsakRevurdering = ÅrsakRevurdering(opplysningskilde = "MODIA", årsak = "ENDRING_I_INNTEKT")
-    )
+    private val vedtak =
+        BehandlingDVH(
+            fagsakId = 100L,
+            behandlingId = 123L,
+            relatertBehandlingId = 110L,
+            adressebeskyttelse = Adressebeskyttelse.UGRADERT,
+            tidspunktVedtak = ZonedDateTime.now(),
+            vilkårsvurderinger =
+                listOf(
+                    VilkårsvurderingDto(Vilkår.LOVLIG_OPPHOLD, Vilkårsresultat.OPPFYLT),
+                    VilkårsvurderingDto(Vilkår.SIVILSTAND, Vilkårsresultat.OPPFYLT),
+                ),
+            person = Person(personIdent = "5634422"),
+            barn = listOf(Barn(personIdent = "6442433")),
+            behandlingType = BehandlingType.REVURDERING,
+            behandlingÅrsak = BehandlingÅrsak.SØKNAD,
+            vedtak = Vedtak.INNVILGET,
+            vedtaksperioder =
+                listOf(
+                    VedtaksperiodeDto(
+                        LocalDate.of(2021, 3, 1),
+                        LocalDate.of(2024, 2, 29),
+                        AktivitetType.BARNET_ER_SYKT,
+                        VedtaksperiodeType.HOVEDPERIODE,
+                    ),
+                ),
+            utbetalinger =
+                listOf(
+                    Utbetaling(
+                        beløp = 100,
+                        samordningsfradrag = 0,
+                        inntekt = 100,
+                        inntektsreduksjon = 0,
+                        LocalDate.of(2021, 3, 1),
+                        LocalDate.of(2024, 2, 29),
+                        Utbetalingsdetalj(Person(personIdent = "5634422"), "EFOG", "EF-123-EF-019"),
+                    ),
+                ),
+            aktivitetskrav =
+                Aktivitetskrav(
+                    aktivitetspliktInntrefferDato = LocalDate.of(2021, 3, 1),
+                    harSagtOppArbeidsforhold = false,
+                ),
+            stønadstype = StønadType.OVERGANGSSTØNAD,
+            kravMottatt = LocalDate.now(),
+            årsakRevurdering = ÅrsakRevurdering(opplysningskilde = "MODIA", årsak = "ENDRING_I_INNTEKT"),
+        )
 
     @Test
     fun `serialiser og deserialiser, forvent ingen unntak`() {
-
         val mapper = ObjectMapper().registerModule(KotlinModule())
         mapper.registerModule(JavaTimeModule())
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/stonadsstatistikk-ks/src/main/kotlin/no/nav/familie/eksterne/kontrakter/Vedtak.kt
+++ b/stonadsstatistikk-ks/src/main/kotlin/no/nav/familie/eksterne/kontrakter/Vedtak.kt
@@ -88,15 +88,20 @@ enum class KompetanseAktivitet {
 enum class KompetanseResultat {
     NORGE_ER_PRIMÆRLAND,
     NORGE_ER_SEKUNDÆRLAND,
-    TO_PRIMÆRLAND
+    TO_PRIMÆRLAND,
 }
-enum class BehandlingType(val visningsnavn: String) {
+
+enum class BehandlingType(
+    val visningsnavn: String,
+) {
     FØRSTEGANGSBEHANDLING("Førstegangsbehandling"),
     REVURDERING("Revurdering"),
     TEKNISK_ENDRING("Teknisk endring"),
 }
 
-enum class BehandlingÅrsak(val visningsnavn: String) {
+enum class BehandlingÅrsak(
+    val visningsnavn: String,
+) {
     SØKNAD("Søknad"),
     ÅRLIG_KONTROLL("Årsak kontroll"),
     DØDSFALL("Dødsfall bruker"),
@@ -130,7 +135,6 @@ enum class Vilkår(
     val harRegelverk: Boolean,
     val eøsSpesifikt: Boolean,
 ) {
-
     BOSATT_I_RIKET(
         parterDetteGjelderFor = listOf(PersonType.SØKER, PersonType.BARN),
         ytelseType = YtelseType.ORDINÆR_KONTANTSTØTTE,
@@ -187,7 +191,9 @@ enum class Vilkår(
         BARN,
     }
 
-    enum class YtelseType(val klassifisering: String) {
+    enum class YtelseType(
+        val klassifisering: String,
+    ) {
         ORDINÆR_KONTANTSTØTTE("KS"), // TODO verdien må avklares med økonomi
     }
 }

--- a/stonadsstatistikk/src/main/kotlin/no/nav/familie/eksterne/kontrakter/VedtakV2.kt
+++ b/stonadsstatistikk/src/main/kotlin/no/nav/familie/eksterne/kontrakter/VedtakV2.kt
@@ -17,7 +17,7 @@ data class VedtakDVHV2(
     val kompetanseperioder: List<Kompetanse>? = null,
     val funksjonellId: String,
     val behandlingÅrsakV2: BehandlingÅrsakV2,
-    val fagsakType: FagsakType? = null
+    val fagsakType: FagsakType? = null,
 )
 
 data class UtbetalingsperiodeDVHV2(
@@ -25,7 +25,7 @@ data class UtbetalingsperiodeDVHV2(
     val utbetaltPerMnd: Int,
     val stønadFom: LocalDate,
     val stønadTom: LocalDate,
-    val utbetalingsDetaljer: List<UtbetalingsDetaljDVHV2>
+    val utbetalingsDetaljer: List<UtbetalingsDetaljDVHV2>,
 )
 
 data class UtbetalingsDetaljDVHV2(
@@ -33,7 +33,7 @@ data class UtbetalingsDetaljDVHV2(
     val klassekode: String,
     val utbetaltPrMnd: Int,
     val delytelseId: String,
-    val ytelseType: YtelseType?
+    val ytelseType: YtelseType?,
 )
 
 data class PersonDVHV2(
@@ -41,7 +41,7 @@ data class PersonDVHV2(
     val rolle: String,
     val statsborgerskap: List<String>,
     val bostedsland: String,
-    val delingsprosentYtelse: Int
+    val delingsprosentYtelse: Int,
 )
 
 data class Kompetanse(
@@ -82,7 +82,7 @@ enum class SøkersAktivitet {
     MOTTAR_UTBETALING_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET,
     MOTTAR_UFØRETRYGD_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET,
     MOTTAR_PENSJON_FRA_NAV_UNDER_OPPHOLD_I_UTLANDET,
-    INAKTIV
+    INAKTIV,
 }
 
 @Deprecated("Skal bruke KompetanseAktivitet")
@@ -93,7 +93,7 @@ enum class AnnenForeldersAktivitet {
     MOTTAR_PENSJON,
     INAKTIV,
     IKKE_AKTUELT,
-    UTSENDT_ARBEIDSTAKER
+    UTSENDT_ARBEIDSTAKER,
 }
 
 enum class KompetanseAktivitet {
@@ -120,19 +120,22 @@ enum class KompetanseAktivitet {
 enum class KompetanseResultat {
     NORGE_ER_PRIMÆRLAND,
     NORGE_ER_SEKUNDÆRLAND,
-    TO_PRIMÆRLAND
+    TO_PRIMÆRLAND,
 }
 
-enum class BehandlingTypeV2(val visningsnavn: String) {
+enum class BehandlingTypeV2(
+    val visningsnavn: String,
+) {
     FØRSTEGANGSBEHANDLING("Førstegangsbehandling"),
     REVURDERING("Revurdering"),
     MIGRERING_FRA_INFOTRYGD("Migrering fra infotrygd"),
     MIGRERING_FRA_INFOTRYGD_OPPHØRT("Opphør migrering fra infotrygd"),
-    TEKNISK_ENDRING("Teknisk endring")
+    TEKNISK_ENDRING("Teknisk endring"),
 }
 
-enum class BehandlingÅrsakV2(val visningsnavn: String) {
-
+enum class BehandlingÅrsakV2(
+    val visningsnavn: String,
+) {
     SØKNAD("Søknad"),
     FØDSELSHENDELSE("Fødselshendelse"),
     ÅRLIG_KONTROLL("Årsak kontroll"),
@@ -152,18 +155,18 @@ enum class BehandlingÅrsakV2(val visningsnavn: String) {
     HELMANUELL_MIGRERING("Manuell migrering"),
     MÅNEDLIG_VALUTAJUSTERING("Månedlig valutajustering"),
     IVERKSETTE_KA_VEDTAK("Iverksette KA-vedtak"),
-    OPPDATER_UTVIDET_KLASSEKODE("Oppdater utvidet klassekode")
+    OPPDATER_UTVIDET_KLASSEKODE("Oppdater utvidet klassekode"),
 }
 
 enum class KategoriV2 {
     EØS,
-    NASJONAL
+    NASJONAL,
 }
 
 enum class UnderkategoriV2 {
     UTVIDET,
     ORDINÆR,
-    INSTITUSJON
+    INSTITUSJON,
 }
 
 enum class FagsakType {
@@ -177,5 +180,5 @@ enum class YtelseType {
     ORDINÆR_BARNETRYGD,
     UTVIDET_BARNETRYGD,
     SMÅBARNSTILLEGG,
-    MANUELL_VURDERING
+    MANUELL_VURDERING,
 }


### PR DESCRIPTION
Oppdatert ktlint.

Det meste er autoformatering men obs på @Suppress-warning i noen tilfeller. 

Maks lengde på linjer (pga kommentarer):
Saksstatistikk-ef/.../BehandlingDvh.kt, Stønadsstatistikk-ef/.../BehandlingDvh.kt, BehandlindsstatistikkKlage

Store forbukstaver i enum:
Skatteetatenperiode.kt
